### PR TITLE
Do not prefix private keys with 0x during wallet gen

### DIFF
--- a/utils/walletGen.ts
+++ b/utils/walletGen.ts
@@ -1,8 +1,7 @@
 import { Wallet } from "ethers";
 import crypto from "crypto";
 
-const id: string = crypto.randomBytes(32).toString("hex");
-const privateKey: string = "0x" + id;
+const privateKey: string = crypto.randomBytes(32).toString("hex");
 console.log("Private Key:", privateKey);
 
 const wallet: Wallet = new Wallet(privateKey);


### PR DESCRIPTION
Most applications will throw an error if the private key starts with `0x`, so to save the generator some pain we generate the private key without the `0x` prefix